### PR TITLE
Small refactoring

### DIFF
--- a/soks.c
+++ b/soks.c
@@ -122,7 +122,7 @@ int main(int argc, char* argv[]) {
     memset(&remote_address, 0, sizeof(struct sockaddr_in));
     server_address.sin_family = AF_INET;
     server_address.sin_port = htons(listen_port);
-    if(!inet_aton(listen_address, (struct in_addr*)&server_address.sin_addr.s_addr)) {
+    if(!inet_aton(listen_address, &server_address.sin_addr)) {
         fprintf(stdout, "Invalid listen address: %s\n", listen_address);
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
Removed unnecessary cast and _class-member-access_.

Although the conversion from a pointer to the type of the first member of a structure to a pointer to the type of this structure is valid and guaranteed to work as expected, it can be omitted in this case, since a pointer to the structure itself is needed.